### PR TITLE
Removes country countryCode and postalCode from popup

### DIFF
--- a/src/components/Popup/PopupContent.tsx
+++ b/src/components/Popup/PopupContent.tsx
@@ -75,9 +75,11 @@ export function PopupContent( props: MarkerProps ): JSX.Element {
 						className={ 'popup-address' }
 						address={ address }
 						city={ city }
-						country={ country }
-						countryCode={ countryCode }
-						postalCode={ postalCode }
+						/*
+              country={ country }
+              countryCode={ countryCode }
+              postalCode={ postalCode }
+						*/
 					/>
 
 					<EmailAddr


### PR DESCRIPTION
Thank you for your contribution, @Alejandra-Goyeiro, for suggesting the change! Removing the country, countryCode, and postalCode labels from the popup seems like a step towards clarity. Simplifying the content can indeed enhance user experience.

We'll proceed with these changes and test for improved usability. If there are further adjustments or feedback, feel free to share them here.

Thanks again for your valuable input! 🙌