### PR TITLE
V1.0.2

### DIFF
--- a/languages/vsge-mapbox-block.pot
+++ b/languages/vsge-mapbox-block.pot
@@ -2,17 +2,17 @@
 # This file is distributed under the GPL-2.0-or-later license.
 msgid ""
 msgstr ""
-"Project-Id-Version: vsge-mapbox-block 0.1.0\n"
+"Project-Id-Version: vsge-mapbox-block 1.0.1\n"
 "Report-Msgid-Bugs-To: codekraft <EMAIL>\n"
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Content-Type: text/plain; charset=iso-8859-1\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
-"POT-Creation-Date: 2024-06-19T20:12:08.451Z\n"
+"POT-Creation-Date: 2024-06-23T23:13:00.505Z\n"
 "PO-Revision-Date: 2024-MO-DA HO:MI+ZONE\n"
 "Last-Translator: codekraft <EMAIL>\n"
 "Language-Team: codekraft <EMAIL>\n"
-"X-Generator: @wp-blocks/make-pot 1.2.0\n"
+"X-Generator: @wp-blocks/make-pot 1.3.2\n"
 "Language: en\n"
 "domain: X-Domain: vsge-mapbox-block\n"
 
@@ -36,250 +36,231 @@ msgstr ""
 msgid "codekraft"
 msgstr ""
 
-#: block.json
-#. title
-msgid "title"
-msgstr ""
-
-#: block.json
-#. description
-msgid "description"
-msgstr ""
-
-#: block.json
-#. keywords
-msgid "keywords"
-msgstr ""
-
-#: src\components\UIComponents\Phone.tsx:29
+#: src/components/UIComponents/Phone.tsx:29
 msgid "Call "
 msgstr ""
 
-#: src\components\UIComponents\EmailAddr.tsx:29
+#: src/components/UIComponents/EmailAddr.tsx:31
 msgid "Email "
 msgstr ""
 
-#: src\components\TopBar\index.tsx:111
+#: src/components/TopBar/index.tsx:113
 msgid "Reset Filters"
 msgstr ""
 
-#: src\components\TopBar\index.tsx:124
+#: src/components/TopBar/index.tsx:126
 msgid "Fit View"
 msgstr ""
 
-#: src\components\TopBar\index.tsx:135
+#: src/components/TopBar/index.tsx:137
 msgid "Select a filter"
 msgstr ""
 
-#: src\components\TopBar\index.tsx:152
+#: src/components/TopBar/index.tsx:154
 msgid "Select a tag"
 msgstr ""
 
-#: src\components\Sortable\SortablePins.tsx:134
-#: src\components\Sortable\index.tsx:156
+#: src/components/Sortable/SortablePins.tsx:134
+#: src/components/Sortable/index.tsx:158
 msgid "New"
 msgstr ""
 
-#: src\components\Sortable\SortablePins.tsx:146
+#: src/components/Sortable/SortablePins.tsx:146
 msgid "type"
 msgstr ""
 
-#: src\components\Sortable\SortablePins.tsx:165
+#: src/components/Sortable/SortablePins.tsx:165
 msgid "lat"
 msgstr ""
 
-#: src\components\Sortable\SortablePins.tsx:184
+#: src/components/Sortable/SortablePins.tsx:184
 msgid "lang"
 msgstr ""
 
-#: src\components\Sortable\SortablePins.tsx:218
+#: src/components/Sortable/SortablePins.tsx:218
 msgid "Add Pin"
 msgstr ""
 
-#: src\components\Sortable\SortablePins.tsx:227
+#: src/components/Sortable/SortablePins.tsx:227
 msgid "Name"
 msgstr ""
 
-#: src\components\Sortable\SortablePins.tsx:242
+#: src/components/Sortable/SortablePins.tsx:242
 msgid "Company"
 msgstr ""
 
-#: src\components\Sortable\SortablePins.tsx:257
-#: src\components\Popup\PopupContent.tsx:65
+#: src/components/Sortable/SortablePins.tsx:257
+#: src/components/Popup/PopupContent.tsx:65
 msgid "Phone"
 msgstr ""
 
-#: src\components\Sortable\SortablePins.tsx:271
-#: src\components\Popup\PopupContent.tsx:70
+#: src/components/Sortable/SortablePins.tsx:271
+#: src/components/Popup/PopupContent.tsx:70
 msgid "Mobile"
 msgstr ""
 
-#: src\components\Sortable\SortablePins.tsx:285
-#: src\components\Popup\PopupContent.tsx:87
-#: src\components\Sidebar\Listing.tsx:149
+#: src/components/Sortable/SortablePins.tsx:285
+#: src/components/Sidebar/Listing.tsx:149
+#: src/components/Popup/PopupContent.tsx:87
 msgid "Email"
 msgstr ""
 
-#: src\components\Sortable\SortablePins.tsx:299
+#: src/components/Sortable/SortablePins.tsx:299
 msgid "website"
 msgstr ""
 
-#: src\components\Sortable\SortablePins.tsx:313
+#: src/components/Sortable/SortablePins.tsx:313
 msgid "City"
 msgstr ""
 
-#: src\components\Sortable\SortablePins.tsx:327
+#: src/components/Sortable/SortablePins.tsx:327
 msgid "Country"
 msgstr ""
 
-#: src\components\Sortable\SortablePins.tsx:341
+#: src/components/Sortable/SortablePins.tsx:341
 msgid "Postal Code"
 msgstr ""
 
-#: src\components\Sortable\SortablePins.tsx:355
+#: src/components/Sortable/SortablePins.tsx:355
 msgid "Country Code"
 msgstr ""
 
-#: src\components\Sortable\SortablePins.tsx:369
+#: src/components/Sortable/SortablePins.tsx:369
 msgid "Address"
 msgstr ""
 
-#: src\components\Sortable\SortablePins.tsx:422
+#: src/components/Sortable/SortablePins.tsx:422
 msgid "Filters"
 msgstr ""
 
-#: src\components\Sortable\SortablePins.tsx:482
+#: src/components/Sortable/SortablePins.tsx:482
 msgid "Select a Marker"
 msgstr ""
 
-#: src\components\Sortable\SortablePins.tsx:490
+#: src/components/Sortable/SortablePins.tsx:490
 msgid "Default"
 msgstr ""
 
-#: src\components\Sortable\SortablePins.tsx:520
+#: src/components/Sortable/SortablePins.tsx:520
 msgid "Marker"
 msgstr ""
 
-#: src\components\Sortable\SortablePins.tsx:568
+#: src/components/Sortable/SortablePins.tsx:568
 msgid "Reset"
 msgstr ""
 
-#: src\components\Sortable\SortablePins.tsx:577
+#: src/components/Sortable/SortablePins.tsx:577
 msgid "Save"
 msgstr ""
 
-#: src\components\Sortable\index.tsx:17
-#: src\components\Sortable\index.tsx:131
+#: src/components/Sortable/index.tsx:17
+#: src/components/Sortable/index.tsx:133
 msgid "New Marker"
 msgstr ""
 
-#: src\components\Sortable\index.tsx:227
-#: src\components\Edit\EditPanelIcons.tsx:119
+#: src/components/Sortable/index.tsx:229
+#: src/components/Edit/EditPanelIcons.tsx:119
 msgid "Add new"
 msgstr ""
 
-#: src\components\Sortable\IconPreview.tsx:28
+#: src/components/Sortable/IconPreview.tsx:28
 msgid "error ??"
 msgstr ""
 
-#: src\components\Popup\PopupContent.tsx:97
-msgid "Distance"
-msgstr ""
-
-#: src\components\Popup\PinPointPopup.tsx:27
-#: src\components\Popup\PinPointPopup.tsx:49
-#: src\components\Popup\PinPointPopup.tsx:57
-msgid "My location"
-msgstr ""
-
-#: src\components\Popup\PinPointPopup.tsx:70
-msgid "Find the nearest store?"
-msgstr ""
-
-#: src\components\Sidebar\Listing.tsx:155
+#: src/components/Sidebar/Listing.tsx:155
 msgid "Distance: "
 msgstr ""
 
-#: src\components\Sidebar\index.tsx:34
+#: src/components/Sidebar/index.tsx:36
 msgid "no listings found"
 msgstr ""
 
-#: src\components\Mapbox\MapboxContext.tsx:96
+#: src/components/Popup/PopupContent.tsx:97
+msgid "Distance"
+msgstr ""
+
+#: src/components/Popup/PinPointPopup.tsx:27
+#: src/components/Popup/PinPointPopup.tsx:49
+#: src/components/Popup/PinPointPopup.tsx:57
+msgid "My location"
+msgstr ""
+
+#: src/components/Popup/PinPointPopup.tsx:70
+msgid "Find the nearest store?"
+msgstr ""
+
+#: src/components/Mapbox/MapboxContext.tsx:97
 msgid "useMapboxContext must be used within a MapboxProvider"
 msgstr ""
 
-#: src\components\Geocoder\init.ts:55
+#: src/components/Geocoder/init.ts:56
 msgid "Find the nearest store"
 msgstr ""
 
-#: src\components\Edit\EditPanelIcons.tsx:32
+#: src/components/Edit/EditPanelIcons.tsx:32
 msgid "Delete icon"
 msgstr ""
 
-#: src\components\Edit\EditPanelIcons.tsx:41
+#: src/components/Edit/EditPanelIcons.tsx:41
 msgid "Marker Name"
 msgstr ""
 
-#: src\components\Edit\EditPanelIcons.tsx:51
+#: src/components/Edit/EditPanelIcons.tsx:51
 msgid "svg markup"
 msgstr ""
 
-#: src\components\Edit\EditPanelIcons.tsx:89
+#: src/components/Edit/EditPanelIcons.tsx:89
 msgid "New Marker "
 msgstr ""
 
-#: src\components\Edit\Edit.tsx:162
+#: src/components/Edit/Edit.tsx:166
 msgid "Enable Sidebar"
 msgstr ""
 
-#: src\components\Edit\Edit.tsx:180
+#: src/components/Edit/Edit.tsx:184
 msgid "Enable Geocoder"
 msgstr ""
 
-#: src\components\Edit\Edit.tsx:194
+#: src/components/Edit/Edit.tsx:198
 msgid "Enable Filters"
 msgstr ""
 
-#: src\components\Edit\Edit.tsx:207
+#: src/components/Edit/Edit.tsx:211
 msgid "Enable Tag"
 msgstr ""
 
-#: src\components\Edit\Edit.tsx:217
+#: src/components/Edit/Edit.tsx:221
 msgid "Enable fitView"
 msgstr ""
 
-#: src\components\Edit\Edit.tsx:231
+#: src/components/Edit/Edit.tsx:235
 msgid "Enable Elevation"
 msgstr ""
 
-#: src\components\Edit\Edit.tsx:245
+#: src/components/Edit/Edit.tsx:249
 msgid "Enable camera 3d rotation"
 msgstr ""
 
-#: src\components\Edit\Edit.tsx:261
+#: src/components/Edit/Edit.tsx:265
 msgid "Enable Zoom with mouse wheel"
 msgstr ""
 
-#: src\components\Edit\Edit.tsx:278
+#: src/components/Edit/Edit.tsx:282
 msgid "Camera Options"
 msgstr ""
 
-#: src\components\Edit\Edit.tsx:287
+#: src/components/Edit/Edit.tsx:292
 msgid "Get Current view"
 msgstr ""
 
-#: src\components\Edit\Edit.tsx:291
+#: src/components/Edit/Edit.tsx:296
 msgid "Camera Fine tuning"
 msgstr ""
 
-#: src\components\Edit\Edit.tsx:294
+#: src/components/Edit/Edit.tsx:299
 msgid "Latitude"
 msgstr ""
 
-#: src\components\Edit\Edit.tsx:312
+#: src/components/Edit/Edit.tsx:318
 msgid "Longitude"
-msgstr ""
-
-#: src\components\Edit\Edit.tsx:404
-msgid "Map Height"
 msgstr ""

--- a/src/components/Sortable/SortablePins.tsx
+++ b/src/components/Sortable/SortablePins.tsx
@@ -162,7 +162,7 @@ export const PinCard = ( props: {
 								} }
 							/>
 							<TextControl
-								label={ __( 'lat', 'vsge-mapbox-block' ) }
+								label={ __( 'long', 'vsge-mapbox-block' ) }
 								value={
 									itemData.geometry.coordinates[ 0 ] || 0
 								}
@@ -181,7 +181,7 @@ export const PinCard = ( props: {
 								}
 							/>
 							<TextControl
-								label={ __( 'lang', 'vsge-mapbox-block' ) }
+								label={ __( 'lat', 'vsge-mapbox-block' ) }
 								value={
 									itemData.geometry.coordinates[ 1 ] || 0
 								}
@@ -215,7 +215,10 @@ export const PinCard = ( props: {
 										},
 									} );
 								} }
-								label={ __( 'Add Pin', 'vsge-mapbox-block' ) }
+								label={ __(
+									'Get position from map',
+									'vsge-mapbox-block'
+								) }
 								showTooltip={ true }
 							/>
 						</Flex>

--- a/src/components/Sortable/index.tsx
+++ b/src/components/Sortable/index.tsx
@@ -6,21 +6,26 @@ import { Button } from '@wordpress/components';
 import { useMapboxContext } from '../Mapbox/MapboxContext';
 import { plusCircle } from '@wordpress/icons';
 import { getNextId, reorder } from '../../utils/dataset';
-import { MapBoxListing, SortableProps } from '../../types';
+import { MapBoxListing, MarkerProps, SortableProps } from '../../types';
 import { LngLatLike } from 'mapbox-gl';
 import { removePopups } from '../Popup/';
 import { defaultColors, defaultMarkerSize } from '../Marker/defaults';
 
 import './style.scss';
 
-export const defaultMarkerProps = {
+export const defaultMarkerProps: MarkerProps = {
 	name: __( 'New Marker', 'vsge-mapbox-block' ),
 	description: '',
 	address: '',
-	location: '',
 	city: '',
-	cap: '',
-	icon: 'default',
+	phone: '',
+	mobile: '',
+	emailAddress: '',
+	country: '',
+	postalCode: '',
+	countryCode: '',
+	website: '',
+	icon: '',
 	iconSize: defaultMarkerSize,
 	iconColor: defaultColors[ 0 ],
 	draggable: false,

--- a/src/components/Sortable/index.tsx
+++ b/src/components/Sortable/index.tsx
@@ -25,7 +25,7 @@ export const defaultMarkerProps: MarkerProps = {
 	postalCode: '',
 	countryCode: '',
 	website: '',
-	icon: '',
+	icon: 'default',
 	iconSize: defaultMarkerSize,
 	iconColor: defaultColors[ 0 ],
 	draggable: false,

--- a/src/components/TopBar/index.tsx
+++ b/src/components/TopBar/index.tsx
@@ -155,9 +155,7 @@ export const TopBar = ( attributes: {
 						},
 						...topbarBuildSelectFromArray( mapboxOptions.tags ),
 					] }
-					onChange={ ( selected ) =>
-						setFilter( selected.target.value )
-					}
+					onChange={ ( selected ) => setTag( selected.target.value ) }
 				/>
 			) : null }
 		</div>

--- a/vsge-mapbox-block.php
+++ b/vsge-mapbox-block.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: vsge-mapbox-block
- * Version: 1.0.1
+ * Version: 1.0.2
  * Description: VSGE - mapbox block
  * Author:            codekraft
  * Text Domain:       vsge-mapbox-block


### PR DESCRIPTION
- fixes the tag filter in the top bar that wasn't enabled
- fix lat/long labels that were reverted
- updated default marker metadata that add the new fields (e.g. "mobile")

close #22